### PR TITLE
Disabled turbolinks

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>
-<body>
+<body data-no-turbolink="true">
   <!-- Flashmeddelanden visas här. Flash[:notice], Flash[:success] osv -->
   <% flash.each do |message_type, message| %>
     <!-- CSS-klassen blir tex "flash-success" eller "flash-notice" -->


### PR DESCRIPTION
Turbolinks messes with the text editor gem..it doesn't load on every sixth page load or so. Works great without it, if we want turbolinks I'll have to look for a fix.