### PR TITLE
enum for role_name_id

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,7 @@
 class Role < ActiveRecord::Base
   has_many :user
+  # Enum role_name maps against the integer-column of the same name in the db
+  # Kinda retarded but at least it eliminates the string-dependencies
+  enum role_name: [:human_resources, :project_manager, :editor, :admin, :user]
+
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -2,6 +2,6 @@ class Role < ActiveRecord::Base
   has_many :user
   # Enum role_name maps against the integer-column of the same name in the db
   # Kinda retarded but at least it eliminates the string-dependencies
-  enum role_name: [:human_resources, :project_manager, :editor, :admin, :user]
+  enum role_name_id: [:human_resources, :project_manager, :editor, :admin, :user]
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,19 +66,19 @@ class User < ActiveRecord::Base
   end
 
   def admin?
-    correct_role? "Admin"
+    self.role.role_name == :admin.to_s
   end
 
   def editor?
-    correct_role? "Redaktör"
+    correct_role? :editor
   end
 
   def human_resources?
-    correct_role? "Personalansvarig"
+    correct_role? :human_resources
   end
 
   def project_manager?
-    correct_role? "Projektledare"
+    correct_role? :project_manager
   end
 
   # Kollar en authentication token mot hashen i databasen

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ActiveRecord::Base
   end
 
   def admin?
-    self.role.role_name == :admin.to_s
+    correct_role? :admin
   end
 
   def editor?
@@ -88,7 +88,7 @@ class User < ActiveRecord::Base
   end
 
   private
-    def correct_role?(role_name)
-      self.role.role_name == role_name
+    def correct_role?(role_name_id)
+      self.role.role_name_id == role_name_id.to_s
     end
 end

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -44,7 +44,7 @@
     <h3>Användar-rättigheter</h3>
     <div class="form-group userInfo">
       <%= f.label :role, "Välj roll" %><br />
-      <%= f.collection_radio_buttons :role_id, Role.all, :id, :role_name, checked: Role.find_by_role_name("Användare").id do |thing| %>
+      <%= f.collection_radio_buttons :role_id, Role.all, :id, :role_name_id, checked: Role.find_by_role_name_id(4).id do |thing| %>
         <div>
          <%= thing.radio_button %>
          <%= thing.label %>

--- a/db/migrate/20160304161506_add_role_enum_to_role_and_remove_role_name_column.rb
+++ b/db/migrate/20160304161506_add_role_enum_to_role_and_remove_role_name_column.rb
@@ -1,0 +1,5 @@
+class AddRoleEnumToRoleAndRemoveRoleNameColumn < ActiveRecord::Migration
+  def change
+    change_column :roles, :role_name, :integer
+  end
+end

--- a/db/migrate/20160304165338_change_role_name_to_role_name_id.rb
+++ b/db/migrate/20160304165338_change_role_name_to_role_name_id.rb
@@ -1,0 +1,6 @@
+class ChangeRoleNameToRoleNameId < ActiveRecord::Migration
+  def change
+    rename_column :roles, :role_name, :role_name_id
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160304161506) do
+ActiveRecord::Schema.define(version: 20160304165338) do
 
   create_table "articles", force: :cascade do |t|
     t.text     "title"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20160304161506) do
   add_index "educations", ["user_id"], name: "index_educations_on_user_id"
 
   create_table "roles", force: :cascade do |t|
-    t.integer  "role_name"
+    t.integer  "role_name_id"
     t.boolean  "can_edit_news",                   default: false
     t.boolean  "can_edit_staff",                  default: false
     t.boolean  "can_edit_tasks",                  default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160303143219) do
+ActiveRecord::Schema.define(version: 20160304161506) do
 
   create_table "articles", force: :cascade do |t|
     t.text     "title"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20160303143219) do
   add_index "educations", ["user_id"], name: "index_educations_on_user_id"
 
   create_table "roles", force: :cascade do |t|
-    t.string   "role_name"
+    t.integer  "role_name"
     t.boolean  "can_edit_news",                   default: false
     t.boolean  "can_edit_staff",                  default: false
     t.boolean  "can_edit_tasks",                  default: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
 # Skapar admin med kontaktperson
 @admin_contact = ContactPerson.create(full_name: "Admins Contact Guy", phone_number: "0722222222", email: "admin@gmail.com")
-@hr = Role.create(description: "Äger rättigheter till personal", role_name: "Personalansvarig", can_edit_staff: true, can_show_person_details_verbose: true)
-@manager = Role.create(description: "Äger rättigheter till att hantera uppgifter.", role_name: "Projektledare", can_edit_tasks: true)
-@editorz = Role.create(description: "Äger rättigheter till nyheter.", role_name: "Redaktör", can_edit_news: true)
-@admin_role = Role.create(description: "Äger rättigheter till hela systemet", role_name: "Admin", can_edit_news: true, can_edit_tasks: true, can_edit_staff: true, can_edit_documents: true, can_show_person_details_verbose: true)
+@hr = Role.create(description: "Äger rättigheter till personal", role_name: :human_resources, can_edit_staff: true, can_show_person_details_verbose: true)
+@manager = Role.create(description: "Äger rättigheter till att hantera uppgifter.", role_name: :project_manager, can_edit_tasks: true)
+@editorz = Role.create(description: "Äger rättigheter till nyheter.", role_name: :editor, can_edit_news: true)
+@admin_role = Role.create(description: "Äger rättigheter till hela systemet", role_name: :admin, can_edit_news: true, can_edit_tasks: true, can_edit_staff: true, can_edit_documents: true, can_show_person_details_verbose: true)
 
 User.create(user_name: "Admin", first_name: "Admin", last_name: "Adminsson",
             password: "adminpassword", password_confirmation: "adminpassword",
@@ -21,7 +21,7 @@ User.create(user_name: "Admin", first_name: "Admin", last_name: "Adminsson",
             password: "testuserpassword", password_confirmation: "testuserpassword",
              email: "mc@user.com", ssn: "123426-1337", phone_number: "0701334999", contact_person: @admin_contact, role: @manager)
 
-@role = Role.create(description: "Äger inga rättigheter", role_name: "Användare")
+@role = Role.create(description: "Äger inga rättigheter", role_name: :user)
 
 # Skapar användare med Faker, varje användare har en kontaktperson
 99.times do |n|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
 # Skapar admin med kontaktperson
 @admin_contact = ContactPerson.create(full_name: "Admins Contact Guy", phone_number: "0722222222", email: "admin@gmail.com")
-@hr = Role.create(description: "Äger rättigheter till personal", role_name: :human_resources, can_edit_staff: true, can_show_person_details_verbose: true)
-@manager = Role.create(description: "Äger rättigheter till att hantera uppgifter.", role_name: :project_manager, can_edit_tasks: true)
-@editorz = Role.create(description: "Äger rättigheter till nyheter.", role_name: :editor, can_edit_news: true)
-@admin_role = Role.create(description: "Äger rättigheter till hela systemet", role_name: :admin, can_edit_news: true, can_edit_tasks: true, can_edit_staff: true, can_edit_documents: true, can_show_person_details_verbose: true)
+@hr = Role.create(description: "Äger rättigheter till personal", role_name_id: :human_resources, can_edit_staff: true, can_show_person_details_verbose: true)
+@manager = Role.create(description: "Äger rättigheter till att hantera uppgifter.", role_name_id: :project_manager, can_edit_tasks: true)
+@editorz = Role.create(description: "Äger rättigheter till nyheter.", role_name_id: :editor, can_edit_news: true)
+@admin_role = Role.create(description: "Äger rättigheter till hela systemet", role_name_id: :admin, can_edit_news: true, can_edit_tasks: true, can_edit_staff: true, can_edit_documents: true, can_show_person_details_verbose: true)
 
 User.create(user_name: "Admin", first_name: "Admin", last_name: "Adminsson",
             password: "adminpassword", password_confirmation: "adminpassword",
@@ -21,7 +21,7 @@ User.create(user_name: "Admin", first_name: "Admin", last_name: "Adminsson",
             password: "testuserpassword", password_confirmation: "testuserpassword",
              email: "mc@user.com", ssn: "123426-1337", phone_number: "0701334999", contact_person: @admin_contact, role: @manager)
 
-@role = Role.create(description: "Äger inga rättigheter", role_name: :user)
+@role = Role.create(description: "Äger inga rättigheter", role_name_id: :user)
 
 # Skapar användare med Faker, varje användare har en kontaktperson
 99.times do |n|

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 admin:
-  role_name: Admin
+  role_name: 3
   can_edit_news: true
   can_edit_staff: true
   can_edit_tasks: true
@@ -10,7 +10,7 @@ admin:
 
 
 user:
-  role_name: User
+  role_name: 4
   can_edit_news: false
   can_edit_staff: false
   can_edit_tasks: false
@@ -18,7 +18,7 @@ user:
   can_show_person_details_verbose: false
 
 editor:
-  role_name: Editor
+  role_name: 2
   can_edit_news: true
   can_edit_staff: false
   can_edit_tasks: false
@@ -26,7 +26,7 @@ editor:
   can_show_person_details_verbose: false
 
 project_manager:
-  role_name: Project manager
+  role_name: 1
   can_edit_news: false
   can_edit_staff: false
   can_edit_tasks: true
@@ -34,7 +34,7 @@ project_manager:
   can_show_person_details_verbose: false
 
 human_resources_representative:
-  role_name: Human resources representative
+  role_name: 0
   can_edit_news: false
   can_edit_staff: true
   can_edit_tasks: false

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 admin:
-  role_name: 3
+  role_name_id: 3
   can_edit_news: true
   can_edit_staff: true
   can_edit_tasks: true
@@ -10,7 +10,7 @@ admin:
 
 
 user:
-  role_name: 4
+  role_name_id: 4
   can_edit_news: false
   can_edit_staff: false
   can_edit_tasks: false
@@ -18,7 +18,7 @@ user:
   can_show_person_details_verbose: false
 
 editor:
-  role_name: 2
+  role_name_id: 2
   can_edit_news: true
   can_edit_staff: false
   can_edit_tasks: false
@@ -26,7 +26,7 @@ editor:
   can_show_person_details_verbose: false
 
 project_manager:
-  role_name: 1
+  role_name_id: 1
   can_edit_news: false
   can_edit_staff: false
   can_edit_tasks: true
@@ -34,7 +34,7 @@ project_manager:
   can_show_person_details_verbose: false
 
 human_resources_representative:
-  role_name: 0
+  role_name_id: 0
   can_edit_news: false
   can_edit_staff: true
   can_edit_tasks: false

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -138,4 +138,10 @@ class UserTest < ActiveSupport::TestCase
     user_search_result = User.search("Nope")
     assert user_search_result.empty?
   end
+
+  test "user role methods" do
+    @user.role = roles(:admin)
+    assert @user.admin?
+
+  end
 end


### PR DESCRIPTION
Issue #167 

changed role_name column in roles to role_name_id
since its now an enum and maps against an integer in the db
seems kinda retarded to have the old name
fixed failing tests etc. bugs that occured after the change