### PR TITLE
fix: can't search on email. see pull request description for more info

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,8 +14,8 @@ class User < ActiveRecord::Base
   before_save { self.full_name = "#{self.first_name} #{self.last_name}" }
 
   # Detta scope används för fuzzy search (behöver inte vara exakta sökningar)
-  scope :search, -> (query) { where "lower(user_name) like ? or lower(last_name) like ? or lower(first_name) or lower(email) like ?",
-                                    "%#{query.downcase}%", "%#{query.downcase}%", "%#{query.downcase}%" }
+  scope :search, -> (query) { where "lower(user_name) like ? or lower(last_name) like ? or lower(first_name) like ?",
+                                  "%#{query.downcase}%", "%#{query.downcase}%", "%#{query.downcase}%" }
   scope :sort, -> (condition) { order("#{condition} desc") }
 
   validates :user_name,      presence: true,


### PR DESCRIPTION
Need to escape the "@" i emails somehow, since I'm placing the search query in the params (so they will be in URL). It works locally but on heroku det fuckar ur. Oh well this is the quick fix